### PR TITLE
implement basic TODOs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,23 +89,27 @@ fn default_amqp_prefetch_count() -> u16  {
   100
 }
 
-// These 2 conn string fn's can become methods on their respective configs
-pub fn format_postgres_connection_string(config: &Config) -> String {
-    format!("postgresql://{}:{}@{}/{}",
-        config.postgres_user,
-        config.postgres_passwd,
-        config.postgres_host,
-        config.postgres_database
-    )
-}
+impl Config {
+	pub fn format_postgres_connection_string(&self) -> String {
+		format!(
+			"postgresql://{}:{}@{}/{}",
+			self.postgres_user,
+			self.postgres_passwd,
+			self.postgres_host,
+			self.postgres_database,
+		)
+	}
 
-pub fn format_amqp_connection_string(config: &Config) -> String {
-    format!("amqp://{}:{}@{}:{}/{}",
-        config.amqp_user,
-        config.amqp_passwd,
-        config.amqp_host,
-        config.amqp_port,
-        config.amqp_vhost)
+	pub fn format_amqp_connection_string(&self) -> String {
+		format!(
+			"amqp://{}:{}@{}:{}/{}",
+			self.amqp_user,
+			self.amqp_passwd,
+			self.amqp_host,
+			self.amqp_port,
+			self.amqp_vhost,
+		)
+	}
 }
 
 pub trait FromPostgresRow {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,19 +207,19 @@ pub struct SipPackage {
     pub timestamp: DateTime<Utc>,
 }
 
-// TODO:
-//fn filename_ext_to_xml<S>(filename: S) -> Option<String>
-//where S: AsRef<Path>
-fn filename_ext_to_xml(filename: String) -> Option<String>
+fn filename_ext_to_xml<S>(file_path: S) -> Option<String>
+where
+	S: AsRef<Path>
 {
-    if filename == "" {
-        None
-    } else {
-        let path = Path::new(&filename);
-        let mut file_stem = path.file_stem().unwrap().to_os_string();
-        file_stem.push(".xml");
-        Some(file_stem.into_string().unwrap())
-    }
+	let file_path_str = file_path.as_ref().to_str().unwrap();
+	if file_path_str.is_empty() {
+		return None;
+	}
+
+	let mut file_stem = file_path.as_ref().file_stem().unwrap().to_os_string();
+	file_stem.push(".xml");
+
+	Some(file_stem.into_string().unwrap())
 }
 
 impl WatchfolderMsg {

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ fn main() -> Result<(), anyhow::Error> {
             println!("Listing batches on {}...\n", &config.postgres_host);
             // Postgres
             log::info!("Connecting to database {} on {}", &config.postgres_database, &config.postgres_host);
-            let connection_string = format_postgres_connection_string(&config);
+            let connection_string = config.format_postgres_connection_string();
             //~ let (client, connection) = tokio_postgres::connect(&connection_string, NoTls).await?;
             let mut client = Client::connect(&connection_string, NoTls)?;
 
@@ -213,13 +213,13 @@ fn main() -> Result<(), anyhow::Error> {
             println!("Starting batch {}...\n", &batch_id);
             // Postgres
             log::info!("Connecting to database {} on {}", &config.postgres_database, &config.postgres_host);
-            let connection_string = format_postgres_connection_string(&config);
+            let connection_string = config.format_postgres_connection_string();
             //~ let (client, connection) = tokio_postgres::connect(&connection_string, NoTls).await?;
             let mut client = Client::connect(&connection_string, NoTls)?;
 
             // AMQP
             // Open AMQP-connection.
-            let connection_string = format_amqp_connection_string(&config);
+            let connection_string = config.format_amqp_connection_string();
             log::info!("Connecting to AMQP on {}", &config.amqp_host);
             log::debug!("Will publish to AMQP q {}", &config.amqp_out_queue);
             let mut connection = Connection::insecure_open(&connection_string)?;
@@ -280,7 +280,7 @@ fn main() -> Result<(), anyhow::Error> {
             }
 
             // Remember to close the AMQP-connection
-            connection.close();
+            connection.close()?;
 
         }
 


### PR DESCRIPTION
### Changes

 - Changed `format_postgres_connection_string` and `format_amqp_connection_string` from functions into methods on the `Config` struct
 - Changed the implementation of `filename_ext_to_xml` to be generic over `S: AsRef<Path>`

Clippy is also outputting a few warnings about the code, if you'd like I can take care of these as well.

Lastly, there are some inconsistencies with the formatting. I'd like to suggest you use `cargo fmt` to establish a common coding style, however the number of changes this will cause will likely mess up your git blame ([this might be useful](https://www.stefanjudis.com/today-i-learned/how-to-exclude-commits-from-git-blame/))

PS.
Say hi to Laura